### PR TITLE
Fix AMD definition for RequireJS

### DIFF
--- a/scrollMonitor.js
+++ b/scrollMonitor.js
@@ -1,5 +1,5 @@
 (function( factory ) {
-	if (typeof define !== 'undefined' && define.amd) {
+	if (typeof define === "function" && define.amd) {
 		define([], factory);
 	} else if (typeof module !== 'undefined' && module.exports) {
 		module.exports = factory();


### PR DESCRIPTION
I was having issues when packaging my project – RequireJS would try to load the module (and fail to find it) rather than look inside its package. Changing the IF clause to be more specific fixed it.